### PR TITLE
Fix assign for other definitions of Maybe

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch src/index.ts"
   }
 }

--- a/src/Just.ts
+++ b/src/Just.ts
@@ -34,7 +34,7 @@ export class Just<A> extends Maybe<A> {
     k: K,
     other: Maybe<B> | ((a: A) => Maybe<B>)
   ): Maybe<A & { [k in K]: B }> {
-    const maybe = other instanceof Maybe ? other : other(this.value);
+    const maybe = typeof other === 'function' ? other(this.value) : other;
     return maybe.map<A & { [k in K]: B }>(b => ({
       ...Object(this.value),
       [k.toString()]: b


### PR DESCRIPTION
When a consuming project has multiple installations of `maybeasy` in `node_modules`, passing a `Maybe` instance to `assign` that was instantiated from another installation will cause `instanceof Maybe` to evaluate `false` when correct operation relies on it being `true`.  It will result in an error like: `Uncaught TypeError: other is not a function  at _Just.assign (Just.js:31:52)`